### PR TITLE
make buildable with msvc and easier to integrate as a library

### DIFF
--- a/Graph.cpp
+++ b/Graph.cpp
@@ -12,6 +12,17 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 
 #include "Graph.h"
 
+#ifdef __GNUC__
+#define likely(cond) __builtin_expect(!!(cond), 1)
+#define unlikely(cond) __builtin_expect(!!(cond), 0)
+#else
+#define likely(cond) (!!(cond))
+#define unlikely(cond) (!!(cond))
+#endif // GNUC
+
+namespace Gorder
+{
+
 string Graph::getFilename(){
 	return name;
 }
@@ -533,7 +544,7 @@ void Graph::GorderGreedy(vector<int>& retorder, int window){
 						unitheap.update[u]=INT_MAX/2;
 #endif
 					if(graph[u].outdegree>1)
-					if(binary_search(&outedge[graph[u].outstart], &outedge[graph[u+1].outstart], v)==false){
+					if(binary_search(outedge.data() + graph[u].outstart, outedge.data() + graph[u+1].outstart, v)==false){
 						for(int j=graph[u].outstart, limit2=graph[u+1].outstart; j<limit2; j++){
 							int w=outedge[j];
 							unitheap.update[w]--;
@@ -555,7 +566,7 @@ void Graph::GorderGreedy(vector<int>& retorder, int window){
 		if(graph[v].outdegree<=hugevertex){
 			for(int i=graph[v].outstart, limit1=graph[v+1].outstart; i<limit1; i++){
 				int w=outedge[i];
-				if(__builtin_expect(unitheap.update[w]==0, 0)){
+				if(unlikely(unitheap.update[w]==0)){
 					unitheap.IncrementKey(w);
 				} else {
 #ifndef Release
@@ -571,7 +582,7 @@ void Graph::GorderGreedy(vector<int>& retorder, int window){
 		for(int i=graph[v].instart, limit1=graph[v+1].instart; i<limit1; i++){
 			int u=inedge[i];
 			if(graph[u].outdegree<=hugevertex){
-				if(__builtin_expect(unitheap.update[u]==0, 0)){
+				if(unlikely(unitheap.update[u]==0)){
 					unitheap.IncrementKey(u);
 				} else {
 #ifndef Release
@@ -585,7 +596,7 @@ void Graph::GorderGreedy(vector<int>& retorder, int window){
 					if(graph[u].outdegree>1)
 					for(int j=graph[u].outstart, limit2=graph[u+1].outstart; j<limit2; j++){
 						int w=outedge[j];
-						if(__builtin_expect(unitheap.update[w]==0, 0)){
+						if(unlikely(unitheap.update[w]==0)){
 							unitheap.IncrementKey(w);
 						}else{
 #ifndef Release
@@ -728,3 +739,4 @@ unsigned long long Graph::LocalityScore(const int w){
 	return sum;
 }
 
+}

--- a/Graph.h
+++ b/Graph.h
@@ -34,6 +34,9 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 #include "Util.h"
 #include "UnitHeap.h"
 
+namespace Gorder
+{
+
 using namespace std;
 
 class Vertex{
@@ -84,6 +87,7 @@ class Graph{
 		unsigned long long LocalityScore(const int w);
 };
 
+}
 
 #endif
 

--- a/UnitHeap.cpp
+++ b/UnitHeap.cpp
@@ -12,6 +12,9 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 
 #include "UnitHeap.h"
 
+namespace Gorder
+{
+
 UnitHeap::UnitHeap(int size){
 	heapsize=size;
 	if(size>0){
@@ -162,3 +165,4 @@ void UnitHeap::ReConstruct(){
 	
 }
 
+}

--- a/UnitHeap.h
+++ b/UnitHeap.h
@@ -20,6 +20,9 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 
 #include "Util.h"
 
+namespace Gorder
+{
+
 using namespace std;
 
 const int INITIALVALUE=0;
@@ -107,6 +110,8 @@ public:
 		}		
 	}
 };
+
+}
 
 
 #endif

--- a/Util.cpp
+++ b/Util.cpp
@@ -1,5 +1,8 @@
 #include "Util.h"
 
+namespace Gorder
+{
+
 unsigned long long MyRand64(){
 	unsigned long long ret, tmp;
 	ret=rand();
@@ -24,3 +27,4 @@ void quit(){
 	exit(0);
 }
 
+}

--- a/Util.h
+++ b/Util.h
@@ -11,6 +11,9 @@
 #include <string>
 #include <cstring>
 
+namespace Gorder
+{
+
 using namespace std;
 
 unsigned long long MyRand64();
@@ -144,6 +147,8 @@ public:
 	}
 
 };
+
+}
 
 #endif
 

--- a/main.cpp
+++ b/main.cpp
@@ -13,12 +13,12 @@
 #include <cstdint>
 #include <cstring>
 #include <chrono>
-#include <sys/time.h>
 
 #include "Graph.h"
 #include "Util.h"
 
 using namespace std;
+using namespace Gorder;
 
 const int INPUTNUM=1;
 
@@ -31,7 +31,7 @@ int main(int argc, char* argv[]){
 
 	if(argc==1){
 		cout << "please provide parameter" << endl;
-		exit(0);
+		quit();
 	}
 
 	i=1;
@@ -72,6 +72,5 @@ int main(int argc, char* argv[]){
 	cout << "Begin Output the Reordered Graph" << endl;
 	g.PrintReOrderedGraph(order);
 	cout << endl;
-
 }
 


### PR DESCRIPTION
- enclosed everything in a namespace
- fix out-of-bounds assert failure in vector access - fixes #1 
- replace _buildin_expect with (un)likely macros conditionally enabled on gnuc only
